### PR TITLE
Fix incompatibility with recent gosa

### DIFF
--- a/personal/mailaddress/class_mailAccount.inc
+++ b/personal/mailaddress/class_mailAccount.inc
@@ -62,7 +62,7 @@ class mailAccount extends plugin {
     /*! \brief  Initialize the mailAccount
      */
     function __construct (&$config,$dn=NULL) {
-        plugin::plugin ($config,$dn);
+        plugin::__construct ($config,$dn);
 
         /* Get attributes from parent object
          */


### PR DESCRIPTION
This fix is required on Debian stretch. See https://bugs.debian.org/869214
I do not know if other API change occurs.
You might want a more generic fix (so that the plugin works with both old and current gosa versions)